### PR TITLE
Dockerfile: Swap alpine to ubuntu to support utf-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM alpine:3.8
+FROM ubuntu:18.04
 
-RUN apk update && \
-    apk add --no-cache html2text=1.3.2a-r0
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y html2text=1.3.2a-21 && \
+    apt-get clean
 
 ENTRYPOINT ["html2text"]


### PR DESCRIPTION
The distributed html2text binary in Ubuntu have one more flag to support
utf-8, because utf-8 is a need, the base image has been swapped from
alpine to ubuntu and all the package installing has been updated
accordingly.

See http://manpages.ubuntu.com/manpages/bionic/man1/html2text.1.html